### PR TITLE
ci: add Hexo deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,47 @@
+name: Deploy Hexo site
+
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: pages-deploy
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Configure Git author
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Clean site
+        run: npx hexo clean
+
+      - name: Build site
+        run: npx hexo generate
+
+      - name: Deploy to live branch
+        run: npx hexo deploy
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,9 @@
 *.vsix
 
 .deploy_git
-.github
+.github/*
+!.github/workflows/
+!.github/workflows/**
 node_modules
 public
 db.json

--- a/_config.yml
+++ b/_config.yml
@@ -108,6 +108,6 @@ theme_config:
 ## Docs: https://hexo.io/docs/one-command-deployment
 deploy:
   type: git
-  repo: git@github.com:ayydany/ayydany.com.git
+  repo: https://github.com/ayydany/ayydany.com.git
   branch: live
   token: $GITHUB_TOKEN


### PR DESCRIPTION
- Add GitHub Actions workflow to build and deploy the Hexo site on pushes to `master`.
- Switch Hexo deploy repo to HTTPS so `GITHUB_TOKEN` works in CI and local deploy can use token-based auth.
- Allow `.github/workflows/**` to be tracked while keeping other generated/local files ignored
