### PR TITLE
fix: use token-aware Hexo deploy config

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -108,6 +108,7 @@ theme_config:
 ## Docs: https://hexo.io/docs/one-command-deployment
 deploy:
   type: git
-  repo: https://github.com/ayydany/ayydany.com.git
-  branch: live
-  token: $GITHUB_TOKEN
+  repo:
+    url: https://github.com/ayydany/ayydany.com.git
+    branch: live
+    token: $GITHUB_TOKEN


### PR DESCRIPTION
- Fix CI deploy auth by changing Hexo deploy `repo` from string form to object form.
- `hexo-deployer-git` only applies `token` when `repo.url` is used, so the previous config pushed to `https://github.com/...` without credentials.

Verification:
- `npx hexo config deploy`
- `env GITHUB_TOKEN=test-token node -e 'const parse=require("./node_modules/hexo-deployer-git/lib/parse_config"); console.log(parse({repo:{url:"https://github.com/ayydany/ayydany.com.git",branch:"live",token:"$GITHUB_TOKEN"}}))'`
