### PR TITLE
fix: use Git credential rewrite for deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,6 +35,11 @@ jobs:
           git config --global user.name "github-actions[bot]"
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
+      - name: Configure Git credentials
+        run: git config --global url."https://x-access-token:${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Clean site
         run: npx hexo clean
 

--- a/_config.yml
+++ b/_config.yml
@@ -108,7 +108,5 @@ theme_config:
 ## Docs: https://hexo.io/docs/one-command-deployment
 deploy:
   type: git
-  repo:
-    url: https://github.com/ayydany/ayydany.com.git
-    branch: live
-    token: $GITHUB_TOKEN
+  repo: https://github.com/ayydany/ayydany.com.git
+  branch: live

--- a/_config.yml
+++ b/_config.yml
@@ -108,6 +108,7 @@ theme_config:
 ## Docs: https://hexo.io/docs/one-command-deployment
 deploy:
   type: git
-  repo: https://github.com/ayydany/ayydany.com.git
-  branch: live
-  token: $GITHUB_TOKEN
+  repo:
+    url: https://github.com/ayydany/ayydany.com.git
+    branch: live
+    token: $GITHUB_TOKEN


### PR DESCRIPTION
- Keep Hexo deploy config on plain HTTPS in `_config.yml`.
- Make GitHub Actions inject `GITHUB_TOKEN` through a Git URL rewrite so `hexo deploy` can push to `live` non-interactively.

Verification:
- `npx hexo config deploy`
